### PR TITLE
#57: Retain hash when downloading + Safari support

### DIFF
--- a/client/src/components/archive-download/archive-download.tsx
+++ b/client/src/components/archive-download/archive-download.tsx
@@ -35,7 +35,7 @@ export default function ArchiveDownload() {
         pendingBackup["hash"] &&
         pendingBackup["hash"] === id && (
           <>
-            <Navigate to="/archive/pending/home" />
+            <Navigate to={"/archive/" + id + "/home"} />
           </>
         )}
     </div>

--- a/client/src/process/Zip.tsx
+++ b/client/src/process/Zip.tsx
@@ -4,7 +4,7 @@ let i = 0;
 let t = 0;
 export class Zip {
   file: any;
-  archiveItems: any = {};
+  archiveItems: ArchiveItems;
   media: any = {};
   archiveSize: any;
 
@@ -217,8 +217,8 @@ export class Zip {
   }
 
   async buildMediaMap() {
-    const { tweet: tweets, profile } = this.archiveItems;
-    const amu = profile ? profile.avatarMediaUrl : "";
+    const { tweet: tweets, profile = { avatarMediaUrl: "" } } = this.archiveItems;
+    const amu = profile.avatarMediaUrl;
     if (amu) {
       let mediaId = amu.substring(amu.lastIndexOf("/") + 1, amu.length);
       this.archiveItems.profile.avatarMediaUrl = this.media[mediaId];
@@ -283,4 +283,11 @@ export class Zip {
       return this.extract(zip);
     });
   }
+}
+
+interface ArchiveItems {
+  tweet: any[];
+  profile: {
+    avatarMediaUrl: string;
+  };
 }

--- a/client/src/process/Zip.tsx
+++ b/client/src/process/Zip.tsx
@@ -217,12 +217,12 @@ export class Zip {
   }
 
   async buildMediaMap() {
-    const {
-      tweet: tweets,
-      profile: { avatarMediaUrl: amu },
-    } = this.archiveItems;
-    let mediaId = amu.substring(amu.lastIndexOf("/") + 1, amu.length);
-    this.archiveItems.profile.avatarMediaUrl = this.media[mediaId];
+    const { tweet: tweets, profile } = this.archiveItems;
+    const amu = profile ? profile.avatarMediaUrl : "";
+    if (amu) {
+      let mediaId = amu.substring(amu.lastIndexOf("/") + 1, amu.length);
+      this.archiveItems.profile.avatarMediaUrl = this.media[mediaId];
+    }
 
     for (let tweet of tweets || []) {
       /* two references of media arrays in a tweet:

--- a/client/src/utils/store.js
+++ b/client/src/utils/store.js
@@ -186,11 +186,12 @@ const StoreProvider = ({ children }) => {
     dispatch({ type: "LOADING" });
     let file = zipFile;
     let uzip = await Zip.unzip(file);
+    let date = file.lastModifiedDate || file.lastModified;
     let zipDetails = {
       name: file.name,
       size: convertBytesToString(file.size),
       type: file.type,
-      lastModifiedDate: file.lastModifiedDate.toString(),
+      lastModifiedDate: date.toString(),
     };
 
     // if unzip does not return any files, it means that the file is not a real twitter backup file


### PR DESCRIPTION
### Description

+ Fixes retaining hash in url when opening (aka downloading) an archive
+ Small fixes to allow Safari support
+ Tweak to properly show "empty archive" error

Fix for #57 